### PR TITLE
[Feat] 전체 메모 리스트 조회 기능 구현

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,3 +12,6 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+
+volumes:
+  mysql-data:

--- a/src/main/java/com/dearme/backend/dearmebe/common/constant/EmotionEmoji.java
+++ b/src/main/java/com/dearme/backend/dearmebe/common/constant/EmotionEmoji.java
@@ -34,5 +34,9 @@ public enum EmotionEmoji {
         }
         throw new CustomException(ErrorCode.INVALID_EMOJI_TYPE, "유효하지 않은 이모지입니다.");
     }
+
+    public boolean isValidScore(int emotionScore) {
+        return this.emotionScore == emotionScore;
+    }
 }
 

--- a/src/main/java/com/dearme/backend/dearmebe/common/util/DateValidator.java
+++ b/src/main/java/com/dearme/backend/dearmebe/common/util/DateValidator.java
@@ -1,4 +1,0 @@
-package com.dearme.backend.dearmebe.common.util;
-
-public class DateValidator {
-}

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
@@ -2,6 +2,7 @@ package com.dearme.backend.dearmebe.domain.memo.controller;
 
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
 import com.dearme.backend.dearmebe.domain.memo.service.MemoService;
 import com.dearme.backend.dearmebe.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -26,5 +27,14 @@ public class MemoController {
         MemoCreateResponse memoResponse = memoService.createMemo(ClientId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("메모 작성 완료", memoResponse));
+    }
+
+    @GetMapping("/api/memos")
+    public ResponseEntity<ApiResponse<MemoListResponse>> getAllMemos(
+            @RequestHeader("X-Client-Id") String clientId
+    ) {
+        MemoListResponse response = memoService.getAllMemos(clientId);
+        return ResponseEntity
+                .ok(ApiResponse.ok("조회 성공", response));
     }
 }

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/request/MemoCreateRequest.java
@@ -12,27 +12,22 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemoCreateRequest {
 
-    // date: YYYY-MM-DD 형식 검증
     @NotBlank(message = "날짜는 필수 입력 값입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)")
     private String date;
 
-    // emoji: 😀/😐/😴/😢/😡 중 1개 (enum을 사용해 명확히 검증)
     @NotBlank(message = "감정 이모지는 필수 입력 값입니다.")
     private String emoji;
 
-    // emotionScore: 0~100 (스트레스 지수 수치화)
     @NotNull(message = "감정 점수는 필수 입력 값입니다.")
     @Min(value = 0, message = "감정 점수는 0점 이상이어야 합니다.")
     @Max(value = 100, message = "감정 점수는 100점 이하여야 합니다.")
     private Integer emotionScore;
 
-    // title: 1~100자
     @NotBlank(message = "제목은 필수 입력 값입니다.")
     @Size(min = 1, max = 100, message = "제목은 1자 이상 100자 이하여야 합니다.")
     private String title;
 
-    // content: 1~10000자
     @NotBlank(message = "내용은 필수 입력 값입니다.")
     @Size(min = 1, max = 10000, message = "내용은 1자 이상 10000자 이하여야 합니다.")
     private String content;

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/request/MemoCreateRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemoCreateRequest {
 
-    // date: YYYY-MM-DD 형식 검증 -> 프론트단 아닌가?
+    // date: YYYY-MM-DD 형식 검증
     @NotBlank(message = "날짜는 필수 입력 값입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)")
     private String date;

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoListResponse.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoListResponse.java
@@ -1,0 +1,44 @@
+package com.dearme.backend.dearmebe.domain.memo.dto.response;
+
+import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class MemoListResponse {
+
+    private String clientId;
+    private List<MemoSimpleResponse> memos;
+
+    public static MemoListResponse from(String clientId, List<Memo> memos) {
+        List<MemoSimpleResponse> memoList = memos.stream()
+                .map(MemoSimpleResponse::from)
+                .collect(Collectors.toList());
+
+        return new MemoListResponse(clientId, memoList);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemoSimpleResponse {
+        private Long memoId;
+        private String date;
+        private String emoji;
+        private String title;
+        private int emotionScore;
+
+        public static MemoSimpleResponse from(Memo memo) {
+            return new MemoSimpleResponse(
+                    memo.getId(),
+                    memo.getDate().toString(),
+                    memo.getEmoji().toString(),
+                    memo.getTitle(),
+                    memo.getEmotionScore()
+            );
+        }
+    }
+}

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/entity/Memo.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/entity/Memo.java
@@ -37,7 +37,6 @@ public class Memo {
     @Column(nullable = false, length = 10000)
     private String content;
 
-    // 기본 생성용 팩토리 (서비스 코드 이용)
     public static Memo createMemo(String clientId, LocalDate date, EmotionEmoji emoji, int emotionScore, String title, String content) {
         Memo memo = new Memo();
         memo.clientId = clientId;
@@ -49,7 +48,6 @@ public class Memo {
         return memo;
     }
 
-    // 오버로딩된 테스트용 팩토리 (id 지정 가능)
     public static Memo createMemo(Long id, String clientId, LocalDate date, EmotionEmoji emoji, int emotionScore, String title, String content) {
         Memo memo = new Memo();
         memo.id = id;
@@ -60,10 +58,6 @@ public class Memo {
         memo.title = title;
         memo.content = content;
         return memo;
-    }
-
-    public boolean isOwner(String clientId) {
-        return this.clientId.equals(clientId);
     }
 }
 

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     List<Memo> findByClientId(String clientId);
-    List<Memo> findAllByClientIdOrderByDateDesc(String clientId);
+    List<Memo> findAllByClientIdOrderByDateAsc(String clientId);
 }
 

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
@@ -27,7 +27,6 @@ public class MemoService {
     public MemoCreateResponse createMemo(String clientId, MemoCreateRequest request) {
         EmotionEmoji emoji = EmotionEmoji.from(request.getEmoji());
 
-        // 감정 점수 검증
         if (!emoji.isValidScore(request.getEmotionScore())) {
             throw new CustomException(
                     ErrorCode.BAD_REQUEST,

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
@@ -3,12 +3,16 @@ package com.dearme.backend.dearmebe.domain.memo.service;
 import com.dearme.backend.dearmebe.common.constant.EmotionEmoji;
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
 import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.repository.MemoRepository;
+import com.dearme.backend.dearmebe.global.exception.CustomException;
+import com.dearme.backend.dearmebe.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional
@@ -21,6 +25,16 @@ public class MemoService {
     }
 
     public MemoCreateResponse createMemo(String clientId, MemoCreateRequest request) {
+        EmotionEmoji emoji = EmotionEmoji.from(request.getEmoji());
+
+        // 감정 점수 검증
+        if (!emoji.isValidScore(request.getEmotionScore())) {
+            throw new CustomException(
+                    ErrorCode.BAD_REQUEST,
+                    String.format("이모지 %s 에 해당하는 감정 점수는 %d입니다.", emoji.getEmoji(), emoji.getEmotionScore())
+            );
+        }
+
         Memo memo = Memo.createMemo(
                 clientId,
                 LocalDate.parse(request.getDate()),
@@ -32,5 +46,15 @@ public class MemoService {
 
         Memo saved = memoRepository.save(memo);
         return MemoCreateResponse.from(saved);
+    }
+
+    public MemoListResponse getAllMemos(String clientId) {
+        List<Memo> memos = memoRepository.findAllByClientIdOrderByDateAsc(clientId);
+
+        if (memos.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_MEMOS_FOUND, "등록된 메모가 없습니다.");
+        }
+
+        return MemoListResponse.from(clientId, memos);
     }
 }

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
@@ -28,10 +28,7 @@ public class MemoService {
         EmotionEmoji emoji = EmotionEmoji.from(request.getEmoji());
 
         if (!emoji.isValidScore(request.getEmotionScore())) {
-            throw new CustomException(
-                    ErrorCode.BAD_REQUEST,
-                    String.format("이모지 %s 에 해당하는 감정 점수는 %d입니다.", emoji.getEmoji(), emoji.getEmotionScore())
-            );
+            throw new CustomException(ErrorCode.INVALID_EMOTION_SCORE, "유효하지 않은 감정 점수입니다.");
         }
 
         Memo memo = Memo.createMemo(

--- a/src/main/java/com/dearme/backend/dearmebe/global/config/JpaConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/JpaConfig.java
@@ -1,4 +1,0 @@
-package com.dearme.backend.dearmebe.global.config;
-
-public class JpaConfig {
-}

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/CustomException.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/CustomException.java
@@ -4,21 +4,24 @@ public class CustomException extends RuntimeException{
     private final ErrorCode errorCode;
     private final String errorMsg;
 
-    public CustomException(ErrorCode errorCode, String errorMsg) {
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
-        this.errorMsg = errorMsg;
+        this.errorMsg = errorCode.getMessage();
     }
 
-    @Override
-    public String getMessage() {
-        return errorCode.getMessage();
+    public CustomException(ErrorCode errorCode, String errorMsg) {
+        super(errorMsg);
+        this.errorCode = errorCode;
+        this.errorMsg = errorMsg;
     }
 
     public ErrorCode getErrorCode() {
         return errorCode;
     }
 
-    public String getErrorMsg() {
+    @Override
+    public String getMessage() {
         return errorMsg;
     }
 }

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     // 메모 관련
     MEMO_NOT_FOUND(404, HttpStatus.NOT_FOUND, "해당 메모를 찾을 수 없습니다."),
+    NO_MEMOS_FOUND(404, HttpStatus.NOT_FOUND, "등록된 메모가 없습니다."),
     MEMO_ACCESS_DENIED(403, HttpStatus.FORBIDDEN, "해당 메모에 접근할 권한이 없습니다."),
     INVALID_MEMO_REQUEST(400, HttpStatus.BAD_REQUEST, "메모 요청 데이터가 올바르지 않습니다."),
     INVALID_DATE_FORMAT(400, HttpStatus.BAD_REQUEST, "날짜 형식은 YYYY-MM-DD 이어야 합니다."),

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_MEMO_REQUEST(400, HttpStatus.BAD_REQUEST, "메모 요청 데이터가 올바르지 않습니다."),
     INVALID_DATE_FORMAT(400, HttpStatus.BAD_REQUEST, "날짜 형식은 YYYY-MM-DD 이어야 합니다."),
     INVALID_EMOJI_TYPE(400, HttpStatus.BAD_REQUEST, "유효하지 않는 이모지입니다."),
+    INVALID_EMOTION_SCORE(400, HttpStatus.BAD_REQUEST, "유효하지 않은 감정 점수입니다."),
 
     // AI 상담 관련
     AI_COUNSEL_FAILED(200, HttpStatus.OK, "AI 상담 응답을 생성하지 못했습니다. 기본 문구로 대체합니다.");

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/GlobalExceptionHandler.java
@@ -20,12 +20,12 @@ public class GlobalExceptionHandler {
     // CustomException 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
-        log.error("Custom Exception: {} - {}", e.getErrorCode(), e.getErrorMsg());
+        log.error("Custom Exception: {} - {}", e.getErrorCode(), e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(ApiResponse.error(
                         e.getErrorCode().getHttpStatus(),
-                        e.getErrorMsg(),
+                        e.getMessage(),
                         null
                 ));
     }

--- a/src/main/java/com/dearme/backend/dearmebe/global/interceptor/ClientIdInterceptor.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/interceptor/ClientIdInterceptor.java
@@ -1,5 +1,0 @@
-package com.dearme.backend.dearmebe.global.interceptor;
-
-public class ClientIdInterceptor {
-    // X-Client-Id 검증을 구현할 예정입니다.
-}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/dearme/backend/dearmebe/domain/repository/MemoRepositoryTest.java
+++ b/src/test/java/com/dearme/backend/dearmebe/domain/repository/MemoRepositoryTest.java
@@ -43,10 +43,30 @@ class MemoRepositoryTest {
 
         memoRepository.save(memo1);
         memoRepository.save(memo2);
-        var all = memoRepository.findAllByClientIdOrderByDateDesc("client123");
+        var all = memoRepository.findAllByClientIdOrderByDateAsc("client123");
 
         assertThat(all).hasSize(2);
         assertThat(all).extracting(Memo::getDate).containsOnly(date);
 
+    }
+
+    @Test
+    void 특정_사용자의_전체_메모리스트를_오름차순으로_조회한다() {
+
+        String clientId = "client123";
+
+        Memo memo1 = Memo.createMemo(clientId, LocalDate.of(2025, 11, 10),
+                EmotionEmoji.HAPPY, 20, "산책", "산책을 해서 기분이 좋았다.");
+        Memo memo2 = Memo.createMemo(clientId, LocalDate.of(2025, 11, 12),
+                EmotionEmoji.SAD, 60, "우울한 하루", "비가 와서 우울했다.");
+
+        memoRepository.save(memo1);
+        memoRepository.save(memo2);
+
+        List<Memo> memos = memoRepository.findAllByClientIdOrderByDateAsc(clientId);
+
+        assertThat(memos).hasSize(2);
+        assertThat(memos.get(0).getDate()).isBefore(memos.get(1).getDate());
+        assertThat(memos.get(0).getTitle()).isEqualTo("산책");
     }
 }

--- a/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
+++ b/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
@@ -3,6 +3,7 @@ package com.dearme.backend.dearmebe.domain.service;
 import com.dearme.backend.dearmebe.common.constant.EmotionEmoji;
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
 import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.repository.MemoRepository;
 import com.dearme.backend.dearmebe.domain.memo.service.MemoService;
@@ -13,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -54,5 +56,39 @@ public class MemoServiceTest {
         MemoCreateResponse response = memoService.createMemo(clientId, request);
 
         assertThat(response.getMemoId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 전체_메모리스트를_정상적으로_조회할_수_있다() {
+
+        String clientId = "client123";
+
+        Memo memo1 = Memo.createMemo(
+                clientId,
+                LocalDate.of(2025, 11, 12),
+                EmotionEmoji.HAPPY,
+                80,
+                "즐거운 날",
+                "케이크 맛집을 찾았다"
+        );
+
+        Memo memo2 = Memo.createMemo(
+                clientId,
+                LocalDate.of(2025, 11, 10),
+                EmotionEmoji.SAD,
+                80,
+                "우울한 하루",
+                "비가 왔다"
+        );
+
+        given(memoRepository.findAllByClientIdOrderByDateAsc(clientId))
+                .willReturn(List.of(memo1, memo2));
+
+        MemoListResponse response = memoService.getAllMemos(clientId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getClientId()).isEqualTo(clientId);
+        assertThat(response.getMemos()).hasSize(2);
+        assertThat(response.getMemos().get(0).getTitle()).isEqualTo("즐거운 날");
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- **전체 메모 리스트 조회 API (`GET /api/memos`) 구현**
    - `X-Client-Id` 헤더를 기반으로 사용자의 모든 메모 조회
    - `MemoRepository`에 `findAllByClientIdOrderByDateAsc()` 메서드 추가
    - `MemoService`에서 조회 로직 구현 (날짜 오름차순 정렬)
    - `MemoListResponse` DTO 생성 (memoId, date, emoji, title, emotionScore 반환)
    - `MemoController`에 GET 엔드포인트 추가
- 예외 처리
    - `X-Client-Id` 누락 시 `400 Bad Request` 응답
    - 정상 조회 시 `200 OK` 응답

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
### 테스트 완료
- **`MemoRepositoryTest`**
    - 같은 사용자 ID로 여러 메모를 저장했을 때, 날짜 오름차순으로 정렬되어 조회되는지 검증 완료
    - 저장된 메모 개수 및 필드값(title, emoji, emotionScore) 정확성 확인
- **`MemoServiceTest`**
    - Mock Repository를 활용해 서비스 계층이 DB 접근 없이 올바른 응답 DTO(`MemoListResponse`)를 반환하는지 테스트 완료     
    - 데이터가 비어있는 경우에도 빈 리스트로 응답되는지 검증 완료

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
### 정상 조회 시 (200 OK)
<img width="682" height="697" alt="스크린샷 2025-11-13 오후 12 46 01" src="https://github.com/user-attachments/assets/dfd691ea-c0e3-4faa-8778-d094149a9e36" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#8 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 전체 메모 리스트 조회 API 정상 동작 확인
- [x] 날짜 오름차순 정렬 검증
- [x] X-Client-Id 누락 시 예외 처리 확인
- [x] 단위 및 통합 테스트 통과
- [x] Swagger 문서 반영 완료