### PR TITLE
[Feat] 메모 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
@@ -2,7 +2,9 @@ package com.dearme.backend.dearmebe.domain.memo.controller;
 
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoDetailResponse;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
+import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.service.MemoService;
 import com.dearme.backend.dearmebe.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
 @RestController
+@RequestMapping("/api/memos")
 public class MemoController {
 
     private final MemoService memoService;
@@ -19,7 +22,7 @@ public class MemoController {
         this.memoService = memoService;
     }
 
-    @PostMapping("/api/memos")
+    @PostMapping
     public ResponseEntity<ApiResponse<MemoCreateResponse>>  createMemo(
             @RequestHeader("X-Client-Id") String ClientId,
             @RequestBody @Valid MemoCreateRequest request
@@ -29,12 +32,22 @@ public class MemoController {
                 .body(ApiResponse.created("메모 작성 완료", memoResponse));
     }
 
-    @GetMapping("/api/memos")
+    @GetMapping
     public ResponseEntity<ApiResponse<MemoListResponse>> getAllMemos(
             @RequestHeader("X-Client-Id") String clientId
     ) {
         MemoListResponse response = memoService.getAllMemos(clientId);
         return ResponseEntity
                 .ok(ApiResponse.ok("조회 성공", response));
+    }
+
+    @GetMapping("/{memoId}")
+    public ResponseEntity<ApiResponse<MemoDetailResponse>> getMemoDetail(
+        @RequestHeader("X-Client-Id") String clientId,
+        @PathVariable Long memoId
+    ) {
+        MemoDetailResponse response = memoService.getMemoDetail(clientId, memoId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok("조회 성공", response));
     }
 }

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/controller/MemoController.java
@@ -4,7 +4,6 @@ import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoDetailResponse;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
-import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.service.MemoService;
 import com.dearme.backend.dearmebe.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -23,10 +22,10 @@ public class MemoController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<MemoCreateResponse>>  createMemo(
+    public ResponseEntity<ApiResponse<MemoCreateResponse>> createMemo(
             @RequestHeader("X-Client-Id") String ClientId,
             @RequestBody @Valid MemoCreateRequest request
-    ){
+    ) {
         MemoCreateResponse memoResponse = memoService.createMemo(ClientId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("메모 작성 완료", memoResponse));
@@ -43,8 +42,8 @@ public class MemoController {
 
     @GetMapping("/{memoId}")
     public ResponseEntity<ApiResponse<MemoDetailResponse>> getMemoDetail(
-        @RequestHeader("X-Client-Id") String clientId,
-        @PathVariable Long memoId
+            @RequestHeader("X-Client-Id") String clientId,
+            @PathVariable Long memoId
     ) {
         MemoDetailResponse response = memoService.getMemoDetail(clientId, memoId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoDetailResponse.java
@@ -1,0 +1,17 @@
+package com.dearme.backend.dearmebe.domain.memo.dto.response;
+
+import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemoDetailResponse {
+
+    private String content;
+
+    public static MemoDetailResponse from(Memo memo) {
+        return new MemoDetailResponse(memo.getContent());
+    }
+
+}

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoListResponse.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/dto/response/MemoListResponse.java
@@ -25,6 +25,7 @@ public class MemoListResponse {
     @Getter
     @AllArgsConstructor
     public static class MemoSimpleResponse {
+
         private Long memoId;
         private String date;
         private String emoji;

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/entity/Memo.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/entity/Memo.java
@@ -59,6 +59,10 @@ public class Memo {
         memo.content = content;
         return memo;
     }
+
+    public boolean isOwner(String clientId) {
+        return this.clientId.equals(clientId);
+    }
 }
 
 

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
@@ -4,10 +4,13 @@ import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     List<Memo> findByClientId(String clientId);
     List<Memo> findAllByClientIdOrderByDateAsc(String clientId);
+
+    Optional<Memo> findById(Long id);
 }
 

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/repository/MemoRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     List<Memo> findByClientId(String clientId);
+
     List<Memo> findAllByClientIdOrderByDateAsc(String clientId);
 
     Optional<Memo> findById(Long id);

--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
@@ -3,6 +3,7 @@ package com.dearme.backend.dearmebe.domain.memo.service;
 import com.dearme.backend.dearmebe.common.constant.EmotionEmoji;
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoDetailResponse;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
 import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.repository.MemoRepository;
@@ -52,5 +53,16 @@ public class MemoService {
         }
 
         return MemoListResponse.from(clientId, memos);
+    }
+
+    public MemoDetailResponse getMemoDetail(String clientId, Long memoId) {
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_NOT_FOUND, "해당 메모를 찾을 수 없습니다."));
+
+        if (!memo.isOwner(clientId)) {
+            throw new CustomException(ErrorCode.MEMO_ACCESS_DENIED, "해당 메모에 접근할 권한이 없습니다.");
+        }
+
+        return MemoDetailResponse.from(memo);
     }
 }

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/CustomException.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/CustomException.java
@@ -1,6 +1,6 @@
 package com.dearme.backend.dearmebe.global.exception;
 
-public class CustomException extends RuntimeException{
+public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
     private final String errorMsg;
 

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/ErrorCode.java
@@ -32,7 +32,6 @@ public enum ErrorCode {
     AI_COUNSEL_FAILED(200, HttpStatus.OK, "AI 상담 응답을 생성하지 못했습니다. 기본 문구로 대체합니다.");
 
 
-
     private final int code;
     private final HttpStatus httpStatus;
     private final String message;
@@ -43,8 +42,16 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    public Integer getCode() { return code; }
-    public HttpStatus getHttpStatus() { return httpStatus; }
-    public String getMessage() { return message; }
+    public Integer getCode() {
+        return code;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }
 

--- a/src/main/java/com/dearme/backend/dearmebe/global/exception/ExceptionDto.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/exception/ExceptionDto.java
@@ -18,7 +18,15 @@ public class ExceptionDto {
         return new ExceptionDto(errorCode, errorMsg);
     }
 
-    public Integer getCode() { return code; }
-    public String getMessage() { return message; }
-    public String getErrorMsg() { return errorMsg; }
+    public Integer getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
 }

--- a/src/test/java/com/dearme/backend/dearmebe/domain/repository/MemoRepositoryTest.java
+++ b/src/test/java/com/dearme/backend/dearmebe/domain/repository/MemoRepositoryTest.java
@@ -6,67 +6,62 @@ import com.dearme.backend.dearmebe.domain.memo.repository.MemoRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class MemoRepositoryTest {
-    
+
+    private static final String CLIENT_ID = "client123";
+    private static final LocalDate DATE = LocalDate.of(2025, 11, 12);
+
     @Autowired
     private MemoRepository memoRepository;
-    
+
+    private Memo createMemo(String title, EmotionEmoji emoji, int score, LocalDate date) {
+        return Memo.createMemo(CLIENT_ID, date, emoji, score, title, "내용입니다.");
+    }
+
     @Test
     void 메모를_저장하고_조회할_수_있다() {
-        Memo memo = Memo.createMemo(
-                "client123",
-                LocalDate.of(2025, 11, 12),
-                EmotionEmoji.HAPPY,
-                80,
-                "기분 좋은 하루",
-                "오늘은 날씨가 좋아서 산책했다."
-        );
 
-        Memo saved = memoRepository.save(memo);
-        List<Memo> found = memoRepository.findByClientId(saved.getClientId());
+        Memo memo = createMemo("기분 좋은 하루", EmotionEmoji.HAPPY, 80, DATE);
+        memoRepository.save(memo);
 
-        assertThat(found).hasSize(1);
-        assertThat(found.get(0).getTitle()).isEqualTo("기분 좋은 하루");
+        List<Memo> found = memoRepository.findByClientId(CLIENT_ID);
+
+        assertThat(found).hasSize(1)
+                .extracting(Memo::getTitle)
+                .containsExactly("기분 좋은 하루");
     }
 
     @Test
     void 같은_날짜에_여러_메모를_저장할_수_있다() {
-        var date = LocalDate.of(2025, 11, 12);
-        var memo1 = Memo.createMemo("client123", date, EmotionEmoji.HAPPY, 80, "제목1", "내용1");
-        var memo2 = Memo.createMemo("client123", date, EmotionEmoji.SAD,   20, "제목2", "내용2");
 
-        memoRepository.save(memo1);
-        memoRepository.save(memo2);
-        var all = memoRepository.findAllByClientIdOrderByDateAsc("client123");
+        Memo memo1 = createMemo("제목1", EmotionEmoji.HAPPY, 80, DATE);
+        Memo memo2 = createMemo("제목2", EmotionEmoji.SAD, 20, DATE);
+        memoRepository.saveAll(List.of(memo1, memo2));
+
+        List<Memo> all = memoRepository.findAllByClientIdOrderByDateAsc(CLIENT_ID);
 
         assertThat(all).hasSize(2);
-        assertThat(all).extracting(Memo::getDate).containsOnly(date);
-
+        assertThat(all).extracting(Memo::getDate).containsOnly(DATE);
     }
 
     @Test
     void 특정_사용자의_전체_메모리스트를_오름차순으로_조회한다() {
 
-        String clientId = "client123";
+        Memo earlier = createMemo("산책", EmotionEmoji.HAPPY, 20, LocalDate.of(2025, 11, 10));
+        Memo later = createMemo("우울한 하루", EmotionEmoji.SAD, 60, LocalDate.of(2025, 11, 12));
+        memoRepository.saveAll(List.of(earlier, later));
 
-        Memo memo1 = Memo.createMemo(clientId, LocalDate.of(2025, 11, 10),
-                EmotionEmoji.HAPPY, 20, "산책", "산책을 해서 기분이 좋았다.");
-        Memo memo2 = Memo.createMemo(clientId, LocalDate.of(2025, 11, 12),
-                EmotionEmoji.SAD, 60, "우울한 하루", "비가 와서 우울했다.");
-
-        memoRepository.save(memo1);
-        memoRepository.save(memo2);
-
-        List<Memo> memos = memoRepository.findAllByClientIdOrderByDateAsc(clientId);
+        List<Memo> memos = memoRepository.findAllByClientIdOrderByDateAsc(CLIENT_ID);
 
         assertThat(memos).hasSize(2);
+        assertThat(memos.getFirst().getTitle()).isEqualTo("산책");
         assertThat(memos.get(0).getDate()).isBefore(memos.get(1).getDate());
-        assertThat(memos.get(0).getTitle()).isEqualTo("산책");
     }
 }

--- a/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
+++ b/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
@@ -3,10 +3,12 @@ package com.dearme.backend.dearmebe.domain.service;
 import com.dearme.backend.dearmebe.common.constant.EmotionEmoji;
 import com.dearme.backend.dearmebe.domain.memo.dto.request.MemoCreateRequest;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoCreateResponse;
+import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoDetailResponse;
 import com.dearme.backend.dearmebe.domain.memo.dto.response.MemoListResponse;
 import com.dearme.backend.dearmebe.domain.memo.entity.Memo;
 import com.dearme.backend.dearmebe.domain.memo.repository.MemoRepository;
 import com.dearme.backend.dearmebe.domain.memo.service.MemoService;
+import com.dearme.backend.dearmebe.global.exception.CustomException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,8 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -36,7 +40,7 @@ public class MemoServiceTest {
         MemoCreateRequest request = new MemoCreateRequest(
                 "2025-11-12",
                 "😀",
-                85,
+                20,
                 "기분 좋은 하루",
                 "날씨가 좋아서 산책했다."
         );
@@ -46,7 +50,7 @@ public class MemoServiceTest {
                 clientId,
                 LocalDate.parse("2025-11-12"),
                 EmotionEmoji.HAPPY,
-                80,
+                20,
                 "기분 좋은 하루",
                 "날씨가 좋아서 산책했다."
         );
@@ -90,5 +94,28 @@ public class MemoServiceTest {
         assertThat(response.getClientId()).isEqualTo(clientId);
         assertThat(response.getMemos()).hasSize(2);
         assertThat(response.getMemos().get(0).getTitle()).isEqualTo("즐거운 날");
+    }
+
+    @Test
+    void 메모를_ID로_정상_조회할_수_있다() {
+
+        String clientId = "client123";
+        Memo memo = Memo.createMemo(clientId, LocalDate.now(), EmotionEmoji.HAPPY, 20, "제목", "내용");
+        given(memoRepository.findById(any(Long.class))).willReturn(Optional.of(memo));
+
+        MemoDetailResponse response = memoService.getMemoDetail(clientId, 1L);
+
+        assertThat(response.getContent()).isEqualTo("내용");
+    }
+
+    @Test
+    void 본인_메모가_아닐_경우_예외가_발생한다() {
+
+        Memo memo = Memo.createMemo("otherUser", LocalDate.now(), EmotionEmoji.HAPPY, 20, "제목", "내용");
+        given(memoRepository.findById(any(Long.class))).willReturn(Optional.of(memo));
+
+        assertThatThrownBy(() -> memoService.getMemoDetail("client123", 1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("해당 메모에 접근할 권한이 없습니다.");
     }
 }

--- a/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
+++ b/src/test/java/com/dearme/backend/dearmebe/domain/service/MemoServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,6 +45,9 @@ public class MemoServiceTest {
 
         MemoCreateRequest request = new MemoCreateRequest("2025-11-12", "😀", 20, "기분 좋은 하루", "날씨가 좋아서 산책했다.");
         Memo memo = makeMemo(CLIENT_ID, "기분 좋은 하루", "날씨가 좋아서 산책했다.", EmotionEmoji.HAPPY);
+
+        ReflectionTestUtils.setField(memo, "id", 1L);
+
         given(memoRepository.save(any(Memo.class))).willReturn(memo);
 
         MemoCreateResponse response = memoService.createMemo(CLIENT_ID, request);


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- `GET /api/memos/{memoId}` 메모 상세 조회 기능 구현
    - 사용자가 특정 메모를 클릭했을 때, 해당 `memoId`로 메모 내용을 조회
    - 본인 메모(`X-Client-Id` 일치)인 경우에만 content 반환
    - 없는 메모 요청 시 `404 Not Found`
    - 본인 메모가 아닐 경우 `403 Forbidden`

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- TDD 기반으로 단계별 구현
    1. **Service 단위 테스트 작성**
        - 정상 조회
        - 접근 권한 예외
    2. **Service 로직 구현 후 통과**
    3. **Controller 테스트 및 통합 확인**

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
- 성공: 200 OK
<img width="573" height="313" alt="스크린샷 2025-11-13 오후 2 24 08" src="https://github.com/user-attachments/assets/5ea6e76d-fa7d-4bcc-a740-72d8bc8da042" />

- 메모ID 불일치: 404 Not Found
<img width="575" height="423" alt="스크린샷 2025-11-13 오후 2 24 54" src="https://github.com/user-attachments/assets/9b0f4014-6fb9-4f60-90c4-3603fadaf7d4" />

- 본인 메모 검증 실패(권한 없을 시): 403 Forbidden
<img width="576" height="305" alt="스크린샷 2025-11-13 오후 2 25 36" src="https://github.com/user-attachments/assets/337e99be-05e7-43ce-a777-0d72ff74d03b" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#10 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 단위 테스트 통과 (`MemoServiceTest`)
- [x] Swagger 문서 확인