### PR TITLE
[Fix] 전체 메모 조회 수정

### DIFF
--- a/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dearme/backend/dearmebe/domain/memo/service/MemoService.java
@@ -48,12 +48,8 @@ public class MemoService {
     public MemoListResponse getAllMemos(String clientId) {
         List<Memo> memos = memoRepository.findAllByClientIdOrderByDateAsc(clientId);
 
-        if (memos.isEmpty()) {
-            throw new CustomException(ErrorCode.NO_MEMOS_FOUND, "등록된 메모가 없습니다.");
-        }
-
         return MemoListResponse.from(clientId, memos);
-    }
+    }  // 듀기 걍 이대로 가묜 되는데여 ㅇㅅㅇ 다시 해볼개 404오류떠요,,,, 무슨 404 오류죠듀기 카톡으로 보내바요
 
     public MemoDetailResponse getMemoDetail(String clientId, Long memoId) {
         Memo memo = memoRepository.findById(memoId)

--- a/src/main/java/com/dearme/backend/dearmebe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/SwaggerConfig.java
@@ -12,6 +12,10 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
 
+        Server localServer = new Server()
+                .url("http://localhost:8080")
+                .description("로컬 테스트 서버");
+
         Server httpsServer = new Server()
                 .url("https://43-200-255-137.nip.io")   // <-- HTTPS 주소
                 .description("배포 서버");
@@ -21,6 +25,6 @@ public class SwaggerConfig {
                         .title("DearMe REST API")
                         .description("DearMe - REST API Swagger 문서")
                         .version("v1.0.0"))
-                .servers(java.util.List.of(httpsServer));
+                .servers(java.util.List.of(localServer, httpsServer));
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 기존에는 특정 사용자의 전체 메모 조회 시, 저장된 메모가 하나도 없으면 `NO_MEMOS_FOUND` 예외를 발생시켜 404 응답을 반환했지만 프론트 요구사항에 의해, 메모가 0개라도 정상 응답(200 OK) + 빈 배열 []을 반환하도록 수정했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="503" height="789" alt="스크린샷 2025-11-16 오전 1 36 42" src="https://github.com/user-attachments/assets/4b1b0081-2fe1-4734-b9f6-3d037d3ba536" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#18 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 빈 배열 응답 구조 확인
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인