### PR TITLE
[Chore] 퍼블릭 IP 변경에 따른 Swagger 서버 URL 수정

### DIFF
--- a/src/main/java/com/dearme/backend/dearmebe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
                 .description("로컬 테스트 서버");
 
         Server httpsServer = new Server()
-                .url("https://43-200-255-137.nip.io")   // <-- HTTPS 주소
+                .url("https://43-201-35-136.nip.io")   // <-- HTTPS 주소
                 .description("배포 서버");
 
         return new OpenAPI()

--- a/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("*") // 배포, 로컬 두 개 만들기.
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE",  "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false);


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- EC2 퍼블릭 IP 변경에 맞추어 SwaggerConfig 의 서버 URL을 최신 nip.io 도메인으로 수정했습니다.
- caddyfile도 변경된 퍼블릭 IP로 수정했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#20 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ]  Swagger UI에서 모든 엔드포인트 정상 호출됨
- [ ] Try it out 실행 시 200 OK 응답 확인
- [ ] Caddy Proxy 경로와 동일한지 확인