### PR TITLE
[Chore] Vercel 배포 도메인 허용을 위한 CORS 설정 업데이트

### DIFF
--- a/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
@@ -10,8 +10,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*") // 배포, 로컬 두 개 만들기.
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE",  "OPTIONS")
+                .allowedOrigins(
+                        "http://localhost:5173",           // 로컬 개발용
+                        "https://dear-me-five.vercel.app"  // 배포된 프론트엔드
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false);
     }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
Vercel에 프론트엔드가 배포되면서, WebConfig의 `allowedOrigins` 설정을 로컬 개발용과 배포용으로 분리하여 추가했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- `http://localhost:5173` — 로컬 개발 환경 (Vite)
- `https://dear-me-five.vercel.app` — 배포된 프론트엔드 도메인

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#22 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ]  CORS 설정 정상 적용
- [ ] 개발/배포 환경 모두 API 호출 정상 동작 확인
- [ ]  Docker 재빌드 및 서버 재배포 완료
