### PR TITLE
[BugFix] Swagger UI용 CORS Origin 추가

### DIFF
--- a/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
+++ b/src/main/java/com/dearme/backend/dearmebe/global/config/WebConfig.java
@@ -12,7 +12,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(
                         "http://localhost:5173",           // 로컬 개발용
-                        "https://dear-me-five.vercel.app"  // 배포된 프론트엔드
+                        "https://dear-me-five.vercel.app",  // 배포된 프론트엔드
+                        "https://43-201-35-136.nip.io"  // Swagger UI 실행 주소
                 )
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
배포된 Swagger UI에서 API 요청 시 발생하던 403 CORS 오류를 해결하기 위해  
스프링 WebConfig의 allowedOrigins 목록에 Swagger UI 도메인을 추가했습니다.

원인은 다음 두 가지로 확인되었습니다:
1) 스프링 WebConfig의 allowedOrigins에 Swagger 도메인이 포함되지 않았습니다.
2) Caddy reverse proxy가 OPTIONS 요청(CORS preflight)을 처리하지 못했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- allowedOrigins에 도메인 주소를 추가했습니다.

- Swagger는 API 요청 전 OPTIONS preflight 요청을 보냅니다. 하지만 기존 Caddy 설정은 OPTIONS 요청을 처리하지 못해 403이 발생했습니다. 이를 해결하기 위해 CORS 프리플라이트 핸들러를 추가했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#24 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인